### PR TITLE
Ignore numpy CVE-2021-41495 until safety db is updated

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -30,7 +30,7 @@ jobs:
           pipenv install --dev --deploy
       - name: Run QA
         run: |
-          pipenv run safety check
+          pipenv run safety check --full-report --ignore 44715
           pipenv run black --check utils tests
           pipenv run flake8 utils tests
           pipenv run mypy --strict utils tests


### PR DESCRIPTION
Ignore CVE-2021-41495 affecting `numpy` until `safety` database is monthly updated.

Links:
- https://github.com/pyupio/safety/issues/364
- https://github.com/numpy/numpy/issues/19038
- https://github.com/advisories/GHSA-5545-2q6w-2gh6