### PR TITLE
Revert "Update actions/upload-pages-artifact action to v4"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This reverts commit 0aef73f90d6bef453fb251e7843b6e95a513b200 because of v4 excluding hidden dot files from the uploaded archive artifact:
- changelog: https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0
- issue: https://github.com/actions/upload-pages-artifact/issues/129

When there is a parameter to configure this to allow uploading `.well-known` folder, will upgrade