### PR TITLE
fix(ci): resolve empty site_url in production e2e tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -218,7 +218,8 @@ jobs:
           path: dist
           include-hidden-files: true
       - id: output_step
-        run: echo "site_url=${SITE_URL}" >> $GITHUB_OUTPUT
+        # Read from file instead of env to avoid GitHub Actions masking secret values in outputs
+        run: echo "site_url=$(cat dist/CNAME)" >> $GITHUB_OUTPUT
 
   deploy-preview:
     name: Deploy Preview


### PR DESCRIPTION
Read site_url from CNAME file instead of env var to avoid GitHub Actions silently dropping job outputs that contain secret values.
